### PR TITLE
Use arm64 image for nextcloudpi

### DIFF
--- a/template/apps/nextcloudpi.json
+++ b/template/apps/nextcloudpi.json
@@ -21,7 +21,7 @@
 	],
 	"extraScript": "reset_premissions_nextcloud.sh",
 	"image32": "ownyourbits/nextcloudpi",
-	"image64": "ownyourbits/nextcloudpi:latest",
+	"image64": "ownyourbits/nextcloudpi-arm64:latest",
 	"name": "nextcloudpi",
 	"note": "The database user is nextcloud and the database is nextcloud_db. The host of the database will be located at the bottom of the DB conotainer in portainer.",
 	"officialDoc": "https://ownyourbits.com/2017/06/08/nextcloudpi-docker-for-raspberry-pi/",


### PR DESCRIPTION
# Summary
Use the arm64 version of docker image for nextcloud pi

# Why This Is Needed
I faced issues trying to run the normal docker image on 64bit raspberry pi os. Switching to the arm64 docker image fixed those issues.

## Fixed
This fix will now make nextcloudpi work on raspberry pi os 64-bit

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
