### PR TITLE
Create filebrowser-s6.json

### DIFF
--- a/template/apps/filebrowser-s6.json
+++ b/template/apps/filebrowser-s6.json
@@ -1,0 +1,48 @@
+{
+	"categories": [
+		"Other",
+		"Tools"
+	],
+	"description": "[arm][s6-version] Web File Browser which can be used as a middleware or standalone app.",
+	"image32": "filebrowser/filebrowser:s6",
+	"image64": "filebrowser/filebrowser:s6",
+	"logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/filebrowser.png",
+	"name": "filebrowser",
+	"note": "The default user and password is admin/admin.",
+	"officialDoc": "https://filebrowser.org/installation#docker",
+	"platform": "linux",
+	"env": [
+		{
+			"default": "1000",
+			"label": "PUID",
+			"name": "PUID"
+		},
+		{
+			"default": "1000",
+			"label": "PGID",
+			"name": "PGID"
+		}
+	],
+	"ports": [
+		"8082:80/tcp"
+	],
+	"restart_policy": "unless-stopped",
+	"title": "FileBrowser",
+	"type": 1,
+	"videoID": 4,
+        "volumes": [
+                {
+                        "bind": "/portainer/Downloads",
+                        "container": "/srv"
+                },
+                {
+                        "bind": "/portainer/Files/AppData/Config/filebrowser/filebrowser.db",
+                        "container": "/database/filebrowser.db"
+                },
+                {
+                        "bind": "/portainer/Files/AppData/Config/filebrowser/settings.json",
+                        "container": "/config/settings.json"
+                }
+	],
+	"webpage": "https://filebrowser.org/"
+}


### PR DESCRIPTION
# Warning we automaticly generate the following files
# docs/README.md, template/portainer-v2-arm32.json, template/portainer-v2-arm64.json, tools/README.md, docs/AppList.md, docs/DocumentList.md, pi-hosted_template/template/portainer-v2.json 
# Please make any changes to these files instead 
# template/apps/*, build/templates/* build/info.json

<!-- The title of the pull request should be a short description of what was done.  -->

<!-- You can remove any parts of this template not applicable to your Pull Request.  -->

# Summary

Filebrowser s6 version

# Why This Is Needed
Default filebrowser will run as root, and not suitable for some setup.

# What Changed
Add filebrowser s6 version

## Added
Ability to use PUID and PGID


<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?
