### PR TITLE
Move macley oled_stats to mklements (official dude)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Pi-Hosted Portainer Template V2 
+# Pi-Hosted Portainer Template V2
 
 [![Discord](https://img.shields.io/discord/316245914987528193?logo=discord)](https://discord.com/invite/v8dAnFV) [![Youtube](https://img.shields.io/badge/YouTube-FF0000?style=flat-square&logo=youtube&logoColor=white)](https://www.youtube.com/channel/UCrjKdwxaQMSV_NDywgKXVmw) [![Twitter URL](https://img.shields.io/twitter/follow/novaspirittech?style=flat-square&logo=twitter)](https://twitter.com/novaspirittech)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Pi-Hosted Portainer Template V2
+# Pi-Hosted Portainer Template V2 
 
 [![Discord](https://img.shields.io/discord/316245914987528193?logo=discord)](https://discord.com/invite/v8dAnFV) [![Youtube](https://img.shields.io/badge/YouTube-FF0000?style=flat-square&logo=youtube&logoColor=white)](https://www.youtube.com/channel/UCrjKdwxaQMSV_NDywgKXVmw) [![Twitter URL](https://img.shields.io/twitter/follow/novaspirittech?style=flat-square&logo=twitter)](https://twitter.com/novaspirittech)
 

--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -6133,7 +6133,7 @@
 				}
 			],
 			"note": "<h3>Template created by Pi-Hosted Series</h3><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.the-diy-life.com/\" target=\"_blank\">https://www.the-diy-life.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/mklements/OLED_Stats_Docker\" target=\"_blank\">https://github.com/mklements/OLED_Stats_Docker</a><br><br><br>Run this command first to enable is2 communication! sudo raspi-config nonint do_i2c 0",
-			"image": "macley/oled_stats:latest",
+			"image": "mklements/oled_stats:latest",
 			"logo": "https://camo.githubusercontent.com/4cf4aaa1e53612347e4d48f152d6d4eea0ce93a6ecacacaa9d44061d0994b408/68747470733a2f2f7777772e7468652d6469792d6c6966652e636f6d2f77702d636f6e74656e742f75706c6f6164732f323032322f30392f3138373137323831322d64653264653635632d626433302d343065372d613835322d3264343234656463323761622e6a7067",
 			"name": "OLED_Stats",
 			"platform": "linux",

--- a/template/apps/oled_stats_SSD1306_128x64.json
+++ b/template/apps/oled_stats_SSD1306_128x64.json
@@ -17,9 +17,9 @@
 		}
 	],
 	"note": "Run this command first to enable is2 communication! sudo raspi-config nonint do_i2c 0",
-	"image_arm32": "macley/oled_stats:latest",
-	"image_arm64": "macley/oled_stats:latest",
-	"image_amd64": "macley/oled_stats:latest",
+	"image_arm32": "mklements/oled_stats:latest",
+	"image_arm64": "mklements/oled_stats:latest",
+	"image_amd64": "mklements/oled_stats:latest",
 	"logo": "https://camo.githubusercontent.com/4cf4aaa1e53612347e4d48f152d6d4eea0ce93a6ecacacaa9d44061d0994b408/68747470733a2f2f7777772e7468652d6469792d6c6966652e636f6d2f77702d636f6e74656e742f75706c6f6164732f323032322f30392f3138373137323831322d64653264653635632d626433302d343065372d613835322d3264343234656463323761622e6a7067",
 	"name": "OLED_Stats",
 	"officialDoc": "https://github.com/mklements/OLED_Stats_Docker",

--- a/template/portainer-v2-amd64.json
+++ b/template/portainer-v2-amd64.json
@@ -6895,7 +6895,7 @@
 				}
 			],
 			"note": "<h3>Template created by Pi-Hosted Series</h3><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.the-diy-life.com/\" target=\"_blank\">https://www.the-diy-life.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/mklements/OLED_Stats_Docker\" target=\"_blank\">https://github.com/mklements/OLED_Stats_Docker</a><br><br><br>Run this command first to enable is2 communication! sudo raspi-config nonint do_i2c 0",
-			"image": "macley/oled_stats:latest",
+			"image": "mklements/oled_stats:latest",
 			"logo": "https://camo.githubusercontent.com/4cf4aaa1e53612347e4d48f152d6d4eea0ce93a6ecacacaa9d44061d0994b408/68747470733a2f2f7777772e7468652d6469792d6c6966652e636f6d2f77702d636f6e74656e742f75706c6f6164732f323032322f30392f3138373137323831322d64653264653635632d626433302d343065372d613835322d3264343234656463323761622e6a7067",
 			"name": "OLED_Stats",
 			"platform": "linux",

--- a/template/portainer-v2-arm32.json
+++ b/template/portainer-v2-arm32.json
@@ -6133,7 +6133,7 @@
 				}
 			],
 			"note": "<h3>Template created by Pi-Hosted Series</h3><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.the-diy-life.com/\" target=\"_blank\">https://www.the-diy-life.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/mklements/OLED_Stats_Docker\" target=\"_blank\">https://github.com/mklements/OLED_Stats_Docker</a><br><br><br>Run this command first to enable is2 communication! sudo raspi-config nonint do_i2c 0",
-			"image": "macley/oled_stats:latest",
+			"image": "mklements/oled_stats:latest",
 			"logo": "https://camo.githubusercontent.com/4cf4aaa1e53612347e4d48f152d6d4eea0ce93a6ecacacaa9d44061d0994b408/68747470733a2f2f7777772e7468652d6469792d6c6966652e636f6d2f77702d636f6e74656e742f75706c6f6164732f323032322f30392f3138373137323831322d64653264653635632d626433302d343065372d613835322d3264343234656463323761622e6a7067",
 			"name": "OLED_Stats",
 			"platform": "linux",

--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -7017,7 +7017,7 @@
 				}
 			],
 			"note": "<h3>Template created by Pi-Hosted Series</h3><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://www.the-diy-life.com/\" target=\"_blank\">https://www.the-diy-life.com/</a><br><b>Official Docker Documentation: </b><a href=\"https://github.com/mklements/OLED_Stats_Docker\" target=\"_blank\">https://github.com/mklements/OLED_Stats_Docker</a><br><br><br>Run this command first to enable is2 communication! sudo raspi-config nonint do_i2c 0",
-			"image": "macley/oled_stats:latest",
+			"image": "mklements/oled_stats:latest",
 			"logo": "https://camo.githubusercontent.com/4cf4aaa1e53612347e4d48f152d6d4eea0ce93a6ecacacaa9d44061d0994b408/68747470733a2f2f7777772e7468652d6469792d6c6966652e636f6d2f77702d636f6e74656e742f75706c6f6164732f323032322f30392f3138373137323831322d64653264653635632d626433302d343065372d613835322d3264343234656463323761622e6a7067",
 			"name": "OLED_Stats",
 			"platform": "linux",


### PR DESCRIPTION
The official image is finnaly out for the oled_stats: mklements/oled_stats
this is the only thing this PR will do. Change mines to his.
After this is merged together with: https://github.com/mklements/OLED_Stats_Docker/pull/3
I'll remove my container image from dockerhub :).