### PR TITLE
Change cadvisor image URL

### DIFF
--- a/stack/raspberrypi-monitoring.yml
+++ b/stack/raspberrypi-monitoring.yml
@@ -14,7 +14,7 @@ services:
     expose:
       - 8080
     hostname: rpi-cadvisor
-    image: zcube/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.47.0
     ipc: shareable
     networks:
       - rpimonitor_default


### PR DESCRIPTION
## Warning we automatically generate the following files, your change(s) will overwritten.
* docs/README.md
* template/portainer-v2-arm32.json
* template/portainer-v2-arm64.json
* template/portainer-v2-amd64.json
* tools/README.md
* docs/AppList.md
* docs/DocumentList.md
* pi-hosted_template/template/portainer-v2.json 

## Please make any changes to these files instead 
* template/apps/`some-application-name.json`
* stack/`some-stack-name.yml` 
* docs/`some-docsname.md`
* tools/`some-script.sh`
* build/info.json

<!-- Fill with - if not applicable-->
## Summary
Use google generated image https://github.com/google/cadvisor

### Why This Is Needed
More updated version

### What Changed
cadvisor version

### Fixed
This should fix cgroup thing, as it will detect cgroup v1 and v2 automatically 🤞🏼 

## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?1
