### PR TITLE
use `:`  instead `.`  as fedora not supporting this compability

### DIFF
--- a/tools/install_flatnotes.sh
+++ b/tools/install_flatnotes.sh
@@ -8,5 +8,5 @@ function error {
 echo "Creating directory..."
 sudo mkdir -p /portainer/Files/AppData/Config/flatnotes || error "Failed to create folder!"
 sudo mkdir -p /portainer/Files/AppData/Config/flatnotes/data || error "Failed to create folder!"
-sudo chown -R 1000.1000 /portainer/Files/AppData/Config/flatnotes || error "Failed to create folder!"
+sudo chown -R 1000:1000 /portainer/Files/AppData/Config/flatnotes || error "Failed to create folder!"
 echo "Setup complete. You can now install Flatnotes using the App Template."

--- a/tools/install_homer.sh
+++ b/tools/install_homer.sh
@@ -8,5 +8,5 @@ function error {
 echo "Creating directory..."
 sudo mkdir -p /portainer/Files/AppData/Config/Homer || error "Failed to create Homer folder!"
 sudo mkdir -p /portainer/Files/AppData/Config/Homer/assets || error "Failed to create Homer folder!"
-sudo chown -R 1000.1000 /portainer/Files/AppData/Config/Homer || error "Failed to create Homer folder!"
+sudo chown -R 1000:1000 /portainer/Files/AppData/Config/Homer || error "Failed to create Homer folder!"
 echo "Setup complete. You can now install the Homer using the App Template."

--- a/tools/install_nextcloud.sh
+++ b/tools/install_nextcloud.sh
@@ -8,5 +8,5 @@ function error {
 echo "Creating directory..."
 sudo mkdir -p /portainer/Files/AppData/Config/Nextcloud/Config || error "Failed to create Config folder!"
 sudo mkdir -p /portainer/Files/AppData/Config/Nextcloud/Data || error "Failed to Data folder!"
-sudo chown -R 1000.1000 /portainer/Files/AppData/Config/Nextcloud || error "Failed set permission Nextloud folder!"
+sudo chown -R 1000:1000 /portainer/Files/AppData/Config/Nextcloud || error "Failed set permission Nextloud folder!"
 echo "Setup complete. You can now install Nextcloud using the App Template. This script specified for Nextcloud stack"

--- a/tools/install_photoprism.sh
+++ b/tools/install_photoprism.sh
@@ -11,13 +11,13 @@ sudo mkdir -p /portainer/Files/AppData/Config/PhotoPrism/database || error "Fail
 sudo mkdir -p /portainer/PhotoPrism || error "Failed to create storage and database directories!"
 
 echo "Setting permissions..."
-sudo chown -R 1000.1000 /portainer/Files/AppData/Config/PhotoPrism/storage || error "Failed to set permissions for PhotoPrism data!"
-sudo chown -R 1000.1000 /portainer/Files/AppData/Config/PhotoPrism/database || error "Failed to set permissions for PhotoPrism data!"
-sudo chown -R 1000.1000 /portainer/PhotoPrism || error "Failed to set permissions for PhotoPrism data!"
+sudo chown -R 1000:1000 /portainer/Files/AppData/Config/PhotoPrism/storage || error "Failed to set permissions for PhotoPrism data!"
+sudo chown -R 1000:1000 /portainer/Files/AppData/Config/PhotoPrism/database || error "Failed to set permissions for PhotoPrism data!"
+sudo chown -R 1000:1000 /portainer/PhotoPrism || error "Failed to set permissions for PhotoPrism data!"
 
 echo
 echo -e "If you already have a folder for images, make sure the user \\e[32mpi\\e[m has access to it."
 echo -e "If required, you can change permissions with:"
-echo -e "   \\e[32msudo chown -R 1000.1000 /path/to/folder\\e[m"
+echo -e "   \\e[32msudo chown -R 1000:1000 /path/to/folder\\e[m"
 echo -e "If not, create it now and give user \\e[32mpi\\e[m permission"
 echo -e "When done you can continue to install PhotoPrism Stack"

--- a/tools/install_vikunja.sh
+++ b/tools/install_vikunja.sh
@@ -22,5 +22,5 @@ sudo mkdir -p /portainer/Files/AppData/Config/Vikunja || error "Failed to create
 echo "Downloading vikunja config files"
 sudo wget -O /portainer/Files/AppData/Config/Vikunja/nginx.conf https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/configs/vikunja_nginx.conf || error "Failed to download nginx.conf file!"
 echo "Setting permissions..."
-sudo chown -R 1000.1000 /portainer/Files/AppData/Config/Vikunja || error "Failed to set permissions for modules data!"
+sudo chown -R 1000:1000 /portainer/Files/AppData/Config/Vikunja || error "Failed to set permissions for modules data!"
 echo "Done You are ready to install the Vikunja Template"

--- a/tools/install_whoogle.sh
+++ b/tools/install_whoogle.sh
@@ -5,20 +5,8 @@ function error {
   exit 1
 }
 
-#function check_internet() {
-#  printf "Checking if you are online..."
-#  wget -q --spider http://github.com
-#  if [ $? -eq 0 ]; then
-#    echo "Online. Continuing."
-#  else
-#    error "Offline. Go connect to the internet then run the script again."
-#  fi
-#}
-
-check_internet
-
 echo "Creating directories..."
 sudo mkdir -p /portainer/Files/AppData/Config/Whoogle || error "Failed to create Whoogle config directory!"
 echo "Setting permissions..."
-sudo chown -R 927.927 /portainer/Files/AppData/Config/Whoogle || error "Failed to set permissions!"
+sudo chown -R 927:927 /portainer/Files/AppData/Config/Whoogle || error "Failed to set permissions!"
 echo "Done You are ready to install the Whoogle Template"

--- a/tools/reset_premissions_nextcloud.sh
+++ b/tools/reset_premissions_nextcloud.sh
@@ -18,9 +18,9 @@ function check_internet() {
 # check_internet
 
 echo "Setting permissions..."
-sudo chown -R root.root /portainer/Files/AppData/Config/ncdata || error "Failed to set permissions!"
-sudo chown -R 33.33 /portainer/Files/AppData/Config/ncdata/nextcloud || error "Failed to set permissions!"
-sudo chown -R 33.33 /portainer/Files/AppData/Config/ncdata/ncp || error "Failed to set permissions!"
-sudo chown -R 101.102 /portainer/Files/AppData/Config/ncdata/database || error "Failed to set permissions!"
+sudo chown -R root:root /portainer/Files/AppData/Config/ncdata || error "Failed to set permissions!"
+sudo chown -R 33:33 /portainer/Files/AppData/Config/ncdata/nextcloud || error "Failed to set permissions!"
+sudo chown -R 33:33 /portainer/Files/AppData/Config/ncdata/ncp || error "Failed to set permissions!"
+sudo chown -R 101:102 /portainer/Files/AppData/Config/ncdata/database || error "Failed to set permissions!"
 sudo chmod -R 755 /portainer/Files/AppData/Config/ncdata/ || error "Failed to set permissions!"
 echo "Permissions are reset to a working config."


### PR DESCRIPTION
## Warning we automatically generate the following files, your change(s) will overwritten.
* docs/README.md
* template/portainer-v2-arm32.json
* template/portainer-v2-arm64.json
* template/portainer-v2-amd64.json
* tools/README.md
* docs/AppList.md
* docs/DocumentList.md
* pi-hosted_template/template/portainer-v2.json 

## Please make any changes to these files instead 
* template/apps/`some-application-name.json`
* stack/`some-stack-name.yml` 
* docs/`some-docsname.md`
* tools/`some-script.sh`
* build/info.json

<!-- Fill with - if not applicable-->
## Summary
Some OS dropping compability support of `.`, as `.` is legacy mode. Look [chown invocation](https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html)

### Why This Is Needed
Supporting OS without legacy support

### What Changed
Replace `.` to `:`

### Added
<!-- What was added? -->
* --
### Function Changed
<!-- Did any functionality change? -->
* --
### Fixed
<!-- Were any bugs fixed? -->
* https://github.com/novaspirit/pi-hosted/issues/429
### Removed
<!-- Was anything removed? -->
* --
### Screenshots
<!-- Please include screenshots of any new features to show how it works. -->
* --
## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?1
