### PR TITLE
Fix "apline" typo in alpine-xfce4-novnc.json

### DIFF
--- a/template/apps/alpine-xfce4-novnc.json
+++ b/template/apps/alpine-xfce4-novnc.json
@@ -21,8 +21,8 @@
 	"type": 1,
         "volumes": [
                 {
-                        "bind": "/portainer/Files/AppData/Config/alpine-xfce4-novnc/home/apline/downloads",
-                        "container": "/home/apline/downloads"
+                        "bind": "/portainer/Files/AppData/Config/alpine-xfce4-novnc/home/alpine/downloads",
+                        "container": "/home/alpine/downloads"
                 }
         ],
 	"webpage": "https://github.com/novaspirit/Alpine_xfce4_noVNC"


### PR DESCRIPTION
## Warning we automatically generate the following files, your change(s) will overwritten.
* docs/README.md
* template/portainer-v2-arm32.json
* template/portainer-v2-arm64.json
* template/portainer-v2-amd64.json
* tools/README.md
* docs/AppList.md
* docs/DocumentList.md
* pi-hosted_template/template/portainer-v2.json 

## Please make any changes to these files instead 
* template/apps/`some-application-name.json`
* stack/`some-stack-name.yml` 
* docs/`some-docsname.md`
* tools/`some-script.sh`
* build/info.json

<!-- Fill with - if not applicable-->
## Summary
<!-- A short summary describing what was done... -->
Fix "apline" typo in alpine-xfce4-novnc.json

### Why This Is Needed
<!-- Explain why this change is needed. Can be omitted if covered in the summary. -->
Presumably the directory named "apline" was supposed to be named alpine? 

The note saying "Default username/password will be alpine/alpine" implies the user (and therefore home directory) was indeed supposed to be named alpine.

### What Changed
<!-- A detailed list of all the changes made, broken down by category. -->
Minor edit - see file change


### Added
<!-- What was added? -->
----------------

### Changed
<!-- Did any functionality change? -->
No

### Fixed
<!-- Were any bugs fixed? -->
Fixes home directory being named "apline" instead of "alpine"

### Removed
<!-- Was anything removed? -->
-----------------

### Screenshots
<!-- Please include screenshots of any new features to show how it works. -->
----------------

## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [Y ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [Y ] Have you added an explanation of what your changes do and why you'd like us to include them?
