### PR TITLE
Update wg-easy in portainer-v3-arm64.json

### DIFF
--- a/template/portainer-v3-arm64.json
+++ b/template/portainer-v3-arm64.json
@@ -10307,10 +10307,10 @@
 					"name": "WG_HOST"
 				},
 				{
-					"default": "ENTER AN ADMIN PASSWORD",
-					"description": "Leave blank to access WebUI without loggin",
-					"label": "PASSWORD",
-					"name": "PASSWORD"
+					"default": "ENTER THE HASH OF THE ADMIN PASSWORD",
+					"description": "Enter the hash of the admin password",
+					"label": "PASSWORDHASH",
+					"name": "PASSWORDHASH"
 				},
 				{
 					"default": "51820",


### PR DESCRIPTION
Update wg-easy in portainer-v3-arm64.json
PASSWORD is no longer supported
It should be PASSWORDHASH

## Warning we automatically generate the following files, your change(s) will overwritten.
* docs/README.md
* template/portainer-v2-arm32.json
* template/portainer-v2-arm64.json
* template/portainer-v2-amd64.json
* template/portainer-v3-arm32.json
* template/portainer-v3-arm64.json
* template/portainer-v3-amd64.json
* tools/README.md
* docs/AppList.md
* docs/DocumentList.md
* pi-hosted_template/template/portainer-v2.json 

## Please make any changes to these files instead 
* template/apps/`some-application-name.json`
* stack/`some-stack-name.yml` 
* docs/`some-docsname.md`
* tools/`some-script.sh`
* build/info.json

<!-- Fill with - if not applicable-->
## Summary
<!-- A short summary describing what was done... -->

### Why This Is Needed
<!-- Explain why this change is needed. Can be omitted if covered in the summary. -->

### What Changed
<!-- A detailed list of all the changes made, broken down by category. -->

### Added
<!-- What was added? -->

### Changed
<!-- Did any functionality change? -->

### Fixed
<!-- Were any bugs fixed? -->

### Removed
<!-- Was anything removed? -->

### Screenshots
<!-- Please include screenshots of any new features to show how it works. -->

## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?1
